### PR TITLE
Processor: Allow for processing interfaces

### DIFF
--- a/ssp-processor/src/main/java/com/github/sdorra/ssp/StaticPermissionProcessor.java
+++ b/ssp-processor/src/main/java/com/github/sdorra/ssp/StaticPermissionProcessor.java
@@ -57,7 +57,7 @@ public class StaticPermissionProcessor extends AbstractProcessor {
   public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
     StaticPermissionModelBuilder builder = new StaticPermissionModelBuilder();
     for (Element e : roundEnv.getElementsAnnotatedWith(StaticPermissions.class)) {
-      if (e.getKind() == ElementKind.CLASS) {
+      if (e.getKind() == ElementKind.CLASS || e.getKind() == ElementKind.INTERFACE) {
         handle(builder, (TypeElement) e);
       }
     }

--- a/ssp-processor/src/test/java/com/github/sdorra/ssp/StaticPermissionProcessorTest.java
+++ b/ssp-processor/src/test/java/com/github/sdorra/ssp/StaticPermissionProcessorTest.java
@@ -7,16 +7,45 @@ import com.google.testing.compile.JavaSourcesSubjectFactory;
 import org.junit.Test;
 
 import javax.tools.JavaFileObject;
-
-import java.util.Arrays;
-
-import static org.junit.Assert.*;
+import java.util.Collections;
 
 public class StaticPermissionProcessorTest {
 
+    final JavaFileObject expectedOutput = JavaFileObjects.forSourceString(
+            "com.example.APermissions",
+            Joiner.on(System.lineSeparator()).join(
+                    "package com.example;",
+                    "",
+                    "import com.github.sdorra.ssp.Constants;",
+                    "import com.github.sdorra.ssp.PermissionCheck;",
+                    "import com.github.sdorra.ssp.PermissionActionCheck;",
+                    "",
+                    "public final class APermissions {",
+                    "",
+                    "  private static final String TYPE = \"a\";",
+                    "",
+                    "  public static final String ACTION_CREATE = \"create\";",
+                    "",
+                    "  private APermissions(){}",
+                    "",
+                    "  public static PermissionCheck create() {",
+                    "    return check(ACTION_CREATE);",
+                    "  }",
+                    "",
+                    "  private static PermissionActionCheck<A> actionCheck(String action) {",
+                    "    return new PermissionActionCheck<>(TYPE.concat(Constants.SEPARATOR).concat(action));",
+                    "  }",
+                    "",
+                    "  private static PermissionCheck check(String permission) {",
+                    "    return new PermissionCheck(TYPE.concat(Constants.SEPARATOR).concat(permission));",
+                    "  }",
+                    "}"
+            )
+    );
+
     @Test
-    public void test() {
-        final JavaFileObject input = JavaFileObjects.forSourceString(
+    public void processClass() {
+        final JavaFileObject clazz = JavaFileObjects.forSourceString(
                 "com.example.A",
                 Joiner.on(System.lineSeparator()).join(
                         "package com.example;",
@@ -34,45 +63,38 @@ public class StaticPermissionProcessorTest {
                         "}"
                 )
         );
-        final JavaFileObject output = JavaFileObjects.forSourceString(
-                "com.example.APermissions",
+
+        processAndAssert(clazz, expectedOutput);
+    }
+
+    @Test
+    public void processInterface() {
+
+        final JavaFileObject interfaze = JavaFileObjects.forSourceString(
+                "com.example.A",
                 Joiner.on(System.lineSeparator()).join(
                         "package com.example;",
                         "",
-                        "import com.github.sdorra.ssp.Constants;",
-                        "import com.github.sdorra.ssp.PermissionCheck;",
-                        "import com.github.sdorra.ssp.PermissionActionCheck;",
+                        "import com.github.sdorra.ssp.StaticPermissions;",
+                        "import com.github.sdorra.ssp.PermissionObject;",
                         "",
-                        "public final class APermissions {",
-                        "",
-                        "  private static final String TYPE = \"a\";",
-                        "",
-                        "  public static final String ACTION_CREATE = \"create\";",
-                        "",
-                        "  private APermissions(){}",
-                        "",
-                        "  public static PermissionCheck create() {",
-                        "    return check(ACTION_CREATE);",
-                        "  }",
-                        "",
-                        "  private static PermissionActionCheck<A> actionCheck(String action) {",
-                        "    return new PermissionActionCheck<>(TYPE.concat(Constants.SEPARATOR).concat(action));",
-                        "  }",
-                        "",
-                        "  private static PermissionCheck check(String permission) {",
-                        "    return new PermissionCheck(TYPE.concat(Constants.SEPARATOR).concat(permission));",
-                        "  }",
+                        "@StaticPermissions(value = \"a\", permissions = {})",
+                        "interface A extends PermissionObject {",
                         "}"
                 )
         );
 
+        processAndAssert(interfaze, expectedOutput);
+    }
+
+    private void processAndAssert(JavaFileObject input, JavaFileObject output) {
         Truth.assert_()
-                .about(JavaSourcesSubjectFactory.javaSources())
-                .that(Arrays.asList(input))
-                .processedWith(new StaticPermissionProcessor())
-                .compilesWithoutError()
-                .and()
-                .generatesSources(output);
+             .about(JavaSourcesSubjectFactory.javaSources())
+             .that(Collections.singletonList(input))
+             .processedWith(new StaticPermissionProcessor())
+             .compilesWithoutError()
+             .and()
+             .generatesSources(output);
     }
 
 }


### PR DESCRIPTION
Exemplary use case: [SCM-Manager](https://bitbucket.org/sdorra/scm-manager/src/9e3108d279e89cbe7be6e8c765041b1b066ec6ac/scm-core/src/main/java/sonia/scm/config/Configuration.java?at=feature%2Fglobal_config_v2_endpoint).

An official release of `shiro-static-permissions` to maven central would also be lovely  :smiley: 